### PR TITLE
Add Troubleshooting Section for Docker Daemon Connection Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,37 @@ jobs:
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
 ```
 
+Certainly! Here's the section you can add to the README.md for `baschny/append-buildx-action`, including the reference to the Docker documentation:
+
+---
+
+Troubleshooting
+---------------
+
+### Issue: Cannot Connect to Docker Daemon
+
+If you encounter the error:
+
+```
+ERROR: Cannot connect to the Docker daemon at http://docker.example.com. Is the docker daemon running?
+```
+
+This is typically a permission issue. To resolve it, follow these steps on your server:
+
+1. **Add Docker Group**: Create a Docker group, if it doesn't exist:
+   ```bash
+   sudo groupadd docker
+   ```
+
+2. **Add User to Docker Group**: Grant Docker permissions to your user:
+   ```bash
+   sudo usermod -aG docker $USER
+   ```
+
+3. **Re-login**: Log out and back in to apply these changes.
+
+For detailed information, refer to Docker's post-installation steps for Linux: [Docker Documentation](https://docs.docker.com/engine/install/linux-postinstall/).
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ jobs:
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
 ```
 
-Certainly! Here's the section you can add to the README.md for `baschny/append-buildx-action`, including the reference to the Docker documentation:
-
----
-
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
## Description
This MR adds a new troubleshooting section to the README.md of the `baschny/append-buildx-action`. The section addresses a common issue users may encounter, specifically the `ERROR: Cannot connect to the Docker daemon at http://docker.example.com. Is the docker daemon running?`. 

## Changes
- Added a "Troubleshooting" section.
- Included steps to resolve Docker daemon connection issues, which typically stem from permission-related problems.
- Provided a reference link to Docker's official post-installation steps for Linux, offering users additional detailed guidance.

## Rationale
Several users have reported encountering permission issues when trying to connect to the Docker daemon using this action. These additions to the README.md aim to provide clear and straightforward guidance on how to resolve such issues, enhancing the user experience and reducing the need for separate support queries.

## Reference
Docker Post-installation Steps for Linux: [Docker Documentation](https://docs.docker.com/engine/install/linux-postinstall/).

I believe this addition will be beneficial for users by providing immediate help for a common problem and enhancing the overall usability of the action.
